### PR TITLE
Mention api.ipify.org is not reachable over IPv6

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,10 @@
                     It works flawlessly with both IPv4 <i>and</i> IPv6 addresses, so
                     no matter what sort of technology you're using, there won't be
                     issues.
+                    <br/>
+                    <b>NOTE</b>: Although <b>ipify</b> supports both IPv4 and IPv6,
+                    <code>https://api.ipify.org</code> itself is not accessible over IPv6 at this time,
+                    so it won't show your IPv6 address -- only IPV4.
                   </li>
                   <li>
                     <b>ipify</b> is completely open source (check out the


### PR DESCRIPTION
The page says that ipify supports both IPv4 and IPv6.
However, there is no AAAA DNS record for api.ipify.org,
so it doesn't work over IPv6.
Mention this explicitly to avoid confusion until
https://github.com/rdegges/ipify-api/issues/3 "ipv6 doesn't seem to be working"
is fixed.